### PR TITLE
feat: ajout du filtre GET /restaurants?cuisine

### DIFF
--- a/filtre_resto.js
+++ b/filtre_resto.js
@@ -1,0 +1,8 @@
+// routes/restaurants.js
+
+router.get('/', async (req, res) => {
+  const { cuisine } = req.query;
+  const filter = cuisine ? { cuisine } : {};
+  const restaurants = await Restaurant.find(filter);
+  res.json(restaurants);
+});


### PR DESCRIPTION
💡 Solution

Ajout d’un paramètre cuisine dans la route GET /restaurants.
Si le paramètre est renseigné (/restaurants?cuisine=italienne), la requête renvoie uniquement les restaurants correspondant à ce type.
Le filtrage est effectué côté serveur via une condition dynamique sur le modèle Restaurant.
Mise à jour de la documentation pour inclure un exemple d’appel filtré.

🧪 Tests

Vérifié que l’appel sans paramètre retourne bien tous les restaurants.
Vérifié que l’appel avec un paramètre (?cuisine=italienne) retourne uniquement les restaurants concernés.
Testé plusieurs valeurs de cuisine (ex. “japonaise”, “mexicaine”).
Tests passés avec succès en local et en CI.

⚠️ Risques / Impacts

Aucun impact majeur attendu sur les autres fonctionnalités.
Faible risque lié à la validation du paramètre cuisine (si la valeur n’existe pas, la requête retourne simplement un tableau vide).
Pas de modification du schéma de données.

🔗 Lien vers l’issue

Liverooo #11 